### PR TITLE
Tukio 4 per topic event broker

### DIFF
--- a/tukio/__init__.py
+++ b/tukio/__init__.py
@@ -1,3 +1,3 @@
-from .engine import Engine, DuplicateWorkflowError
+from .engine import Engine, LoadWorkflowError
 from .workflow import WorkflowTemplate, Workflow, unlock_workflow_when_done
 from .task import TaskRegistry, TaskHolder, UnknownTaskName

--- a/tukio/broker.py
+++ b/tukio/broker.py
@@ -76,7 +76,7 @@ class Broker(object):
             else:
                 self._loop.call_soon(handler, data)
 
-    def register(self, coro_or_cb, topic=None):
+    def register(self, coro_or_cb, topic=None, everything=False):
         """
         Registers a handler (i.e. a coroutine or a regular function/method) to
         be executed upon receiving new events.

--- a/tukio/broker.py
+++ b/tukio/broker.py
@@ -26,14 +26,19 @@ class _BrokerRegistry:
         return broker
 
 
+class BrokerDeleteTopicError(Exception):
+    pass
+
+
 class Broker(object):
 
     """
     The workflow engine has a global event broker that gathers external events
     (e.g. from the network) and internal events (e.g. from tasks) and schedules
     the execution of registered handlers.
-    An event is fired with a topic. Registered handlers are executed each time
-    an event is fired on that topic.
+    If an event is disptached with a topic, all handlers registered with that
+    topic will be executed. Else, all handers (whatever the topic) will be
+    executed.
 
     Note: this class is not thread-safe. Its methods must be called from within
     the same thread as the thread running the event loop used by the workflow
@@ -42,36 +47,99 @@ class Broker(object):
 
     def __init__(self, loop=None):
         self._loop = loop or asyncio.get_event_loop()
-        self._handlers = []
+        self._handlers = dict()
+        self._topics = dict()
 
-    def dispatch(self, data):
+    def add_topic(self, topic):
+        """
+        Adds a new topic to register handlers with.
+        """
+        if topic in self._topics:
+            return
+        self._topics[topic] = set()
+
+    def del_topic(self, topic):
+        """
+        Deletes an existing topic. Raises `BrokerDeleteTopicError` if handlers
+        are still registered with that topic of if the topic doesn't exist.
+        """
+        try:
+            handlers = self._topics[topic]
+        except KeyError:
+            raise BrokerDeleteTopicError("topic {} doesn't "
+                                         "exist".format(topic))
+        if handlers:
+            raise BrokerDeleteTopicError("handlers still registered "
+                                         "with {}".format(topic))
+        del self._topics[topic]
+
+    def dispatch(self, data, topic=None):
         """
         Passes an event (aka the data) received to each registered handler.
+        If topic is not None, the event is dispatched to handlers registered
+        to that topic only. Else it is dispatched to all handlers.
+        Even if a handler was registered multiple times in multiple topics, it
+        will be executed only once per call to `dispatch()`.
         """
-        for handler in self._handlers:
+        if topic is not None:
+            try:
+                handlers = self._topics[topic]
+            except KeyError:
+                handlers = set()
+        else:
+            handlers = self._handlers
+        for handler in handlers:
             if asyncio.iscoroutinefunction(handler):
                 asyncio.ensure_future(handler(data), loop=self._loop)
             else:
                 self._loop.call_soon(handler, data)
 
-    def register(self, coro_or_cb):
+    def register(self, coro_or_cb, topic=None):
         """
-        Registers a coroutine or a regular function to be executed upon
-        receiving events.
+        Registers a handler (i.e. a coroutine or a regular function) to be
+        executed upon receiving new events.
+        If topic is not None, the handler will receive all events dispatched in
+        that topic only. Else it will receive all events dispatched by the
+        broker.
+        A handler can be registered multiple times in different topics. But a
+        handler can neither be registered as global when already per-topic nor
+        per-topic when already global.
         """
         if not inspect.isfunction(coro_or_cb):
             raise TypeError('{} is not a function'.format(coro_or_cb))
-        self._handlers.append(coro_or_cb)
+        # Handler already registered with topics?
+        curr_topics = self._handlers.get(coro_or_cb)
+        if topic is not None:
+            if curr_topics == set():
+                raise ValueError('{} already registered as global'
+                                 ' handler'.format(coro_or_cb))
+            # Topics must have been added prior to registering handlers
+            self._topics[topic].add(coro_or_cb)
+            try:
+                self._handlers[coro_or_cb].add(topic)
+            except KeyError:
+                self._handlers[coro_or_cb] = {topic}
+        else:
+            if curr_topics:
+                raise ValueError('{} already registered with'
+                                 ' topics {}'.format(coro_or_cb, curr_topics))
+            self._handlers[coro_or_cb] = set()
 
-    def unregister(self, coro_or_cb):
+    def unregister(self, coro_or_cb, topic=None):
         """
-        Removes a coroutine or a regular function from the registered handlers.
+        Unregisters a per-topic or a global handler. If topic is None, all
+        registrations (even per-topic) of that handler will be removed.
         """
-        try:
-            self._handlers.remove(coro_or_cb)
-        except ValueError:
-            warn = '{} is not registered in broker, cannot unregister'
-            log.warning(warn.format(coro_or_cb))
+        if topic is not None:
+            self._topics[topic].remove(coro_or_cb)
+            self._handlers[coro_or_cb].remove(topic)
+            if not self._handlers[coro_or_cb]:
+                del self._handlers[coro_or_cb]
+        else:
+            curr_topics = self._handlers[coro_or_cb]
+            for ct in curr_topics:
+                self._topics[ct].remove(coro_or_cb)
+            del self._handlers[coro_or_cb]
 
 
 def get_broker(loop=None):

--- a/tukio/broker.py
+++ b/tukio/broker.py
@@ -36,7 +36,7 @@ class Broker(object):
     The workflow engine has a global event broker that gathers external events
     (e.g. from the network) and internal events (e.g. from tasks) and schedules
     the execution of registered handlers.
-    A handler can be registerd as global (receives all events) or per-topic
+    A handler can be registered as global (receives all events) or per-topic
     (receives events only from its registered topics).
     If an event is disptached with a topic, all handlers registered with that
     topic will be executed as well as all global handlers. Else, only global

--- a/tukio/dag.py
+++ b/tukio/dag.py
@@ -110,8 +110,6 @@ class DAG(object):
         for nodes in self.graph.values():
             successors.update(nodes)
         root_nodes = list(all_nodes - successors)
-        if not root_nodes:
-            raise DAGValidationError('no root node found')
         return root_nodes
 
     def validate(self):

--- a/tukio/engine.py
+++ b/tukio/engine.py
@@ -14,13 +14,17 @@ log = logging.getLogger(__name__)
 
 
 class LoadWorkflowError(Exception):
-    def __init__(self, new_tmpl, current_tmpl):
+
+    def __init__(self, new_tmpl, current_tmpl, message=None):
         super().__init__()
         self.new = new_tmpl
         self.current = current_tmpl
+        self.message = message
 
     def __str__(self):
         err = 'cannot load {}, it is not newer than {}'
+        if self.message is not None:
+            err = err + '. ' + self.message
         return err.format(self.new, self.current)
 
 

--- a/tukio/engine.py
+++ b/tukio/engine.py
@@ -250,8 +250,12 @@ class Engine(asyncio.Future):
             templates = self._selector.get(topic)
             # Try to trigger new workflows from the current dict of workflow
             # templates at all times!
+            wflows = []
             for tmpl in templates:
-                await self._run_in_task(self._try_run, tmpl, data)
+                wflow = await self._run_in_task(self._try_run, tmpl, data)
+                if wflow:
+                    wflows.append(wflow)
+        return wflows
 
     def _try_run(self, template, data):
         """

--- a/tukio/engine.py
+++ b/tukio/engine.py
@@ -5,7 +5,7 @@ import asyncio
 import weakref
 import logging
 
-from tukio.workflow import WorkflowTemplate, OverrunPolicy, new_workflow
+from tukio.workflow import OverrunPolicy, new_workflow
 from tukio.broker import get_broker
 from tukio.task import tukio_factory
 

--- a/tukio/engine.py
+++ b/tukio/engine.py
@@ -242,6 +242,7 @@ class Engine(asyncio.Future):
         which in turn will disptach this event to the right running workflows
         and may trigger new workflow executions.
         """
+        log.debug("data received '%s' in topic '%s'", data, topic)
         self._broker.dispatch(data, topic)
         # Don't start new workflow instances if `stop()` was called.
         if self._must_stop:
@@ -277,6 +278,7 @@ class Engine(asyncio.Future):
                 wflow.run(data)
         else:
             log.debug("skip new workflow from %s (overrun policy)", template)
+        return wflow
 
     async def _wait_abort(self, running, callback):
         """

--- a/tukio/task/holder.py
+++ b/tukio/task/holder.py
@@ -46,6 +46,12 @@ class TaskHolder:
         self.config = config
         self.uid = str(uuid4())
 
+    def data_received(self, data):
+        """
+        This callback is executed if the broker must pass a new event to the
+        task. Override this method to handle data as expected by the task.
+        """
+
     def report(self):
         """
         Returns an execution report (a dict). When defined, this method is used

--- a/tukio/task/task.py
+++ b/tukio/task/task.py
@@ -53,8 +53,8 @@ class TaskRegistry:
     def get(cls, task_name):
         try:
             return cls._registry[task_name]
-        except KeyError as ke:
-            raise UnknownTaskName(ke)
+        except KeyError as exc:
+            raise UnknownTaskName(exc)
 
     @classmethod
     def all(cls):

--- a/tukio/task/template.py
+++ b/tukio/task/template.py
@@ -54,7 +54,7 @@ class TaskTemplate:
             }
 
         The parameters 'topics' and 'config' are both optional.
-        See below the behavior of a task at runtime according to the values of
+        See below the behavior of a task at runtime according to the value of
         'topics':
             {"topics": None}
             the task will receive ALL data disptached by the broker

--- a/tukio/utils.py
+++ b/tukio/utils.py
@@ -29,3 +29,33 @@ def future_state(future):
     if future._exception:
         return FutureState.exception
     return FutureState.finished
+
+
+class Listen(Enum):
+
+    """
+    A simple enumeration of the expected behaviors of a task regarding its
+    ability to receive new data during execution:
+        'everything': receive all data dispatched by the event broker
+        'nothing': receive no data at all during execution
+        'topics': receive data dispatched only in template's topics
+    """
+
+    everything = "everything"
+    nothing = "nothing"
+    topics = "topics"
+
+
+def topics_to_listen(topics):
+    """
+    Maps the value of `topics` to the corresponding event listening behavior
+    of a task.
+    """
+    if topics is None:
+        return Listen.everything
+    elif topics == []:
+        return Listen.nothing
+    elif isinstance(topics, list):
+        return Listen.topics
+    else:
+        raise TypeError("'{}' is not a list".format(topics))

--- a/tukio/workflow.py
+++ b/tukio/workflow.py
@@ -9,6 +9,7 @@ from uuid import uuid4
 from tukio.dag import DAG, DAGValidationError
 from tukio.task import TaskTemplate, TaskRegistry
 from tukio.utils import future_state
+from tukio.broker import get_broker
 
 
 log = logging.getLogger(__name__)
@@ -331,8 +332,8 @@ class Workflow(asyncio.Future):
         # 'skip-until-unlock'.
         if self.policy is OverrunPolicy.skip_until_unlock:
             self.lock._locked = True
-        # Optionally work with an event broker
-        self._broker = broker
+        # Work with an event broker
+        self._broker = broker or get_broker(self._loop)
 
     @property
     def template_id(self):

--- a/tukio/workflow.py
+++ b/tukio/workflow.py
@@ -213,8 +213,9 @@ class WorkflowTemplate(object):
             {
                 "title": <workflow-title>,
                 "id": <workflow-uid>,
-                "vesion": <version>,
+                "version": <version>,
                 "tags": [<a-tag>, <another-tag>],
+                "topics": [<a-topic>, <another-topic>],
                 "tasks": [
                     {"id": <task-uid>, "name": <name>, "config": <cfg-dict>},
                     ...
@@ -225,6 +226,8 @@ class WorkflowTemplate(object):
                     ...
                 }
             }
+
+        Only 'title' is mandatory to create a workflow template.
         """
         # 'title' is the only mandatory key
         title, uid = wf_dict['title'], wf_dict.get('id')

--- a/tukio/workflow.py
+++ b/tukio/workflow.py
@@ -392,6 +392,8 @@ class Workflow(asyncio.Future):
         """
         if topics is None:
             itertopics = [None]
+        else:
+            itertopics = topics
         for topic in itertopics:
             try:
                 self._broker.unregister(callback, topic=topic)

--- a/tukio/workflow.py
+++ b/tukio/workflow.py
@@ -128,7 +128,7 @@ class OverrunPolicyHandler:
         return self._new_wflow()
 
 
-class WorkflowTemplate(object):
+class WorkflowTemplate:
 
     """
     A workflow template is a DAG (Directed Acyclic Graph) made up of task
@@ -285,6 +285,13 @@ class WorkflowTemplate(object):
         for task in self.tasks:
             TaskRegistry.get(task.name)
         return True
+
+    def __str__(self):
+        """
+        Human readable string representation of a workflow template.
+        """
+        wfstr = "<WorkflowTemplate title={}, uid={}, version={}>"
+        return wfstr.format(self.title, self.uid, self.version)
 
 
 class Workflow(asyncio.Future):

--- a/tukio/workflow.py
+++ b/tukio/workflow.py
@@ -420,7 +420,7 @@ class Workflow(asyncio.Future):
             task = task_tmpl.new_task(*args, loop=self._loop, **kwargs)
             # Register the `data_received` callback (if required) as soon as
             # the execution of the task is scheduled.
-            self._register_broker(task_impl)
+            self._register_to_broker(task_tmpl)
         except Exception as exc:
             log.error('failed to create task %s: raised %s', task_tmpl, exc)
             self._internal_exc = exc


### PR DESCRIPTION
This work mainly adds the ability to pass a tuple of `(data, topic)` to the workflow engine.
Previously, the workflow engine tried to trigger a workflow each time it received a new data set (we call it an _event_) and it passed this data to all callbacks registered in the internal event broker.
From now on, it is possible to make an association between a data set and a _topic_ (something like a _channel_ in a pub/sub):
* Trigger workflows only when data is available in user-defined topics (can also be all data received or none)
* Register per-topic or global callbacks so that running tasks can get new data sets at runtime while avoiding to implement complex filtering in the implementation of the task itself.

The configuration dictionaries of a workflow has been slightly updated to add a new `topics` parameter at the workflow level and at the task level.