### PR TITLE
Tukio 14 fix abort running

### DIFF
--- a/tukio/broker.py
+++ b/tukio/broker.py
@@ -96,6 +96,7 @@ class Broker(object):
                 raise ValueError('{} already registered with'
                                  ' topics'.format(coro_or_cb))
             self._global_handlers.add(coro_or_cb)
+            log.debug('registered global handler: %s', coro_or_cb)
         # Register a per-topic handler
         else:
             if coro_or_cb in self._global_handlers:
@@ -105,6 +106,7 @@ class Broker(object):
                 self._topic_handlers[topic].add(coro_or_cb)
             except KeyError:
                 self._topic_handlers[topic] = {coro_or_cb}
+            log.debug('registered topic handler: %s', coro_or_cb)
 
     def unregister(self, coro_or_cb, topic=None):
         """

--- a/tukio/task/template.py
+++ b/tukio/task/template.py
@@ -2,7 +2,7 @@ import logging
 from uuid import uuid4
 
 from .task import new_task
-from tukio.utils import topics_to_listen
+from tukio.utils import Listen
 
 
 log = logging.getLogger(__name__)
@@ -17,7 +17,7 @@ class TaskTemplate:
     `asyncio.Task`) and provide execution report.
     """
 
-    def __init__(self, name, uid=None, config=None, topics=[]):
+    def __init__(self, name, uid=None, config=None, topics=None):
         self.name = name
         self.config = config
         self.topics = topics
@@ -25,7 +25,7 @@ class TaskTemplate:
 
     @property
     def listen(self):
-        return topics_to_listen(self.topics)
+        return Listen.get(self.topics)
 
     def new_task(self, inputs, loop=None):
         """
@@ -51,6 +51,7 @@ class TaskTemplate:
         'topics':
             {"topics": None}
             the task will receive ALL data disptached by the broker
+            ** default behavior **
 
             {"topics": []}
             the task will receive NO data from the broker
@@ -62,7 +63,7 @@ class TaskTemplate:
         uid = task_dict.get('id')
         name = task_dict['name']
         config = task_dict.get('config')
-        topics = task_dict.get('topics', [])
+        topics = task_dict.get('topics')
         return cls(name, uid=uid, config=config, topics=topics)
 
     def as_dict(self):

--- a/tukio/utils.py
+++ b/tukio/utils.py
@@ -17,18 +17,18 @@ class FutureState(Enum):
     exception = 'exception'
     finished = 'finished'
 
-
-def future_state(future):
-    """
-    Returns the state of a future as an enumeration member (from `FutureState`)
-    """
-    if not future.done():
-        return FutureState.pending
-    if future.cancelled():
-        return FutureState.cancelled
-    if future._exception:
-        return FutureState.exception
-    return FutureState.finished
+    @classmethod
+    def get(cls, future):
+        """
+        Returns the state of a future as `FutureState` member
+        """
+        if not future.done():
+            return cls.pending
+        if future.cancelled():
+            return cls.cancelled
+        if future._exception:
+            return cls.exception
+        return cls.finished
 
 
 class Listen(Enum):
@@ -45,17 +45,16 @@ class Listen(Enum):
     nothing = "nothing"
     topics = "topics"
 
-
-def topics_to_listen(topics):
-    """
-    Maps the value of `topics` to the corresponding event listening behavior
-    of a task.
-    """
-    if topics is None:
-        return Listen.everything
-    elif topics == []:
-        return Listen.nothing
-    elif isinstance(topics, list):
-        return Listen.topics
-    else:
-        raise TypeError("'{}' is not a list".format(topics))
+    @classmethod
+    def get(cls, topics):
+        """
+        Returns event listening behavior of a task as a `Listen` member
+        """
+        if topics is None:
+            return cls.everything
+        elif topics == []:
+            return cls.nothing
+        elif isinstance(topics, list):
+            return cls.topics
+        else:
+            raise TypeError("'{}' is not a list".format(topics))

--- a/tukio/workflow.py
+++ b/tukio/workflow.py
@@ -87,9 +87,9 @@ class OverrunPolicyHandler:
         return method(running)
 
     def _check_wflow(self, wflow):
-        if wflow.template_id != self.template.uid:
+        if wflow.template.uid != self.template.uid:
             err = 'expected template ID {}'', got {}'
-            raise ValueError(err.format(self.template.uid, wflow.template_id))
+            raise ValueError(err.format(self.template.uid, wflow.template.uid))
 
     def _new_wflow(self):
         return Workflow(self.template, loop=self._loop)
@@ -352,8 +352,8 @@ class Workflow(asyncio.Future):
         self._broker = broker or get_broker(self._loop)
 
     @property
-    def template_id(self):
-        return self._template.uid
+    def template(self):
+        return self._template
 
     @property
     def policy(self):
@@ -564,7 +564,7 @@ class Workflow(asyncio.Future):
         """
         string = ("<Workflow template_id={}, template_title={}, uid={}, "
                   "start={}, end={}>")
-        tmpl_id, title = self.template_id, self._template.title
+        tmpl_id, title = self._template.uid, self._template.title
         return string.format(tmpl_id, title, self.uid, self._start, self._end)
 
     def report(self):


### PR DESCRIPTION
The `abort-running` overrun policy was fixed. It now properly cancels a running workflow (with the same template) prior to triggering a new instance.

The default event listening behavior of tasks was also fixed (it was blocking the functionnal validation of the `abort-running` fix). Now tasks receive all data received by the engine by default. If there's no callback defined to process the data, it is just ignored to avoid the hassle of explicitely configuring each task (e.g. tasks implemented as simple coroutines) to receive no data.
Anyway, the user is warned on loading a new workflow template if such a situation occurs (a task without a `data_received` callback whereas all tasks should receive all data by default)