### PR TITLE
Tukio 36 cleanup trigger workflow

### DIFF
--- a/tukio/engine.py
+++ b/tukio/engine.py
@@ -3,7 +3,6 @@ Tukio Workflow Engine
 """
 import asyncio
 import logging
-import weakref
 
 from tukio.workflow import OverrunPolicy, new_workflow, Workflow
 from tukio.broker import get_broker

--- a/tukio/engine.py
+++ b/tukio/engine.py
@@ -285,9 +285,10 @@ class Engine(asyncio.Future):
         if self._must_stop:
             log.debug("The engine is stopping, cannot trigger new workflows")
             return
-        running = self._instances.get(template.uid)
         # Always apply the policy of the current workflow template (workflow
         # instances may run with another version of the template)
+        running = [i for i in self._instances
+                   if i.template.uid == template.uid]
         wflow = new_workflow(template, running=running, loop=self._loop)
         if wflow:
             if template.policy == OverrunPolicy.abort_running and running:


### PR DESCRIPTION
The engine now has two methods:

- `trigger` to try to trigger a loaded workflow (and apply the overrun policy)
- `run_once` to force run a workflow template (not loaded) for testing purpose

The `run_once` method (formerly `side_run`) has been turned into a coroutine.
NB: we could turn back all `data_received`, `trigger` and `run_once` methods into simple methods. The need for async methods is not that clear.