### PR TITLE
Execute all code in task context

### DIFF
--- a/tukio/task/factory.py
+++ b/tukio/task/factory.py
@@ -26,6 +26,9 @@ class TukioTask(asyncio.Task):
         self._template = None
         self._workflow = None
         self._source = None
+        self._queue = asyncio.Queue(loop=self._loop)
+        if self.holder:
+            self.holder.queue = self._queue
 
     @property
     def template(self):
@@ -38,6 +41,18 @@ class TukioTask(asyncio.Task):
     @property
     def event_source(self):
         return self._source
+
+    @property
+    def queue(self):
+        return self._queue
+
+    async def data_received(self, event):
+        """
+        A handler that puts events into the task's own receiving queue. This
+        handler shall be registered in the data broker so that any tukio task
+        can receive and process events during execution.
+        """
+        await self._queue.put(event)
 
     def in_progress(self):
         """

--- a/tukio/task/holder.py
+++ b/tukio/task/holder.py
@@ -25,8 +25,6 @@ Which turns into a more compact class when you inherit your own class from
 """
 from uuid import uuid4
 
-from tukio.broker import get_broker
-
 
 class TaskHolder:
 
@@ -52,16 +50,6 @@ class TaskHolder:
         # to will land into that queue.
         # This `queue` attribute is auto set by `TukioTask` at init.
         self.queue = None
-
-    def subscribe(self, topic):
-        """
-        A shorthand method to register the standard `TukioTask.data_received`
-        coroutine with a new topic in the data broker.
-        This is an easy way to get events from a new topic into the receiving
-        queue.
-        """
-        coro = asyncio.Task.current_task().data_received
-        get_broker().register(coro, topic=topic)
 
     def report(self):
         """


### PR DESCRIPTION
Tukio tasks can now receive events through a _queue_.

The developer still can register a _handler_ to process _events_ from a _topic_.
But that way, the code of the handler will be executed outside of the task's execution context.
Which leads to many issues when working in such handlers:
* Cannot get the task's context nor the current associated workflow
* Cannot raise an exception or set the result of the task

In order to execute all code in the task's exec context, I refactored a few things:
* `TukioTask` objects now have a `.queue` attribute which is an instance of `asyncio.Queue`
* A shorthand has been added to `TaskHolder` to access it with a simple `self.queue`
* A new `TopicManager` class enables to subscribe/unsubscribe to a _topic_ during task's execution
* Once subscribed to a _topic_ each _event_ dispatched to that _topic_ will be put into the task's _queue_.
* `TopicManager` is also a context manager so as to allow: `with TopicManager(topic)` and nest some code that deals with _events_ dispatched to that _topic_ 