### PR TITLE
Drastically speed up workflows' startup (through DAG and OverrunPolicy)

### DIFF
--- a/tukio/dag.py
+++ b/tukio/dag.py
@@ -49,12 +49,6 @@ class DAG(object):
         if predecessor not in self.graph or successor not in self.graph:
             raise KeyError('nodes do not exist in graph')
         self.graph[predecessor].add(successor)
-        try:
-            self.validate()
-        except (KeyError, DAGValidationError) as exc:
-            # Rollback the last update if it breaks the DAG
-            self.graph[predecessor].remove(successor)
-            raise exc
 
     def delete_edge(self, predecessor, successor):
         """
@@ -102,6 +96,7 @@ class DAG(object):
                 raise TypeError('dict values must be lists')
             for succ in successors:
                 dag.add_edge(node, succ)
+        dag.validate()
         return dag
 
     def root_nodes(self):

--- a/tukio/engine.py
+++ b/tukio/engine.py
@@ -158,9 +158,9 @@ class Engine(asyncio.Future):
         try:
             wflow.result()
         except asyncio.CancelledError:
-            log.warning('workflow %s has been cancelled', wflow)
+            log.info('Workflow %s has been cancelled', wflow.uid[:8])
         except Exception as exc:
-            log.warning('workflow %s ended on exception', wflow)
+            log.warning('Workflow %s ended on exception', wflow.uid[:8])
             log.exception(exc)
 
         if self._must_stop and not self._instances and not self.done():

--- a/tukio/task/factory.py
+++ b/tukio/task/factory.py
@@ -173,11 +173,13 @@ class TukioTask(asyncio.Task):
             )
             return result
 
-    def dispatch_progress(self, data, event_type=TaskExecState.progress.value):
+    def dispatch_progress(self, data, event_type=None):
         """
         Dispatch task progress events in the 'EXEC_TOPIC' from
         this tukio task.
         """
+        if event_type is None:
+            event_type = TaskExecState.progress.value
         event_data = {'type': event_type, 'content': data}
         self._broker.dispatch(
             event_data,

--- a/tukio/workflow.py
+++ b/tukio/workflow.py
@@ -297,12 +297,15 @@ class WorkflowTemplate:
             task_ids[task_tmpl.uid] = task_tmpl
 
         # Graph
+        for up_id, down_ids_set in wf_dict.get('graph', {}).items():
+            up_tmpl = task_ids[up_id]
+            for down_id in down_ids_set:
+                down_tmpl = task_ids[down_id]
+                wf_tmpl.link(up_tmpl, down_tmpl)
+
+        # Graph validation
         try:
-            for up_id, down_ids_set in wf_dict.get('graph', {}).items():
-                up_tmpl = task_ids[up_id]
-                for down_id in down_ids_set:
-                    down_tmpl = task_ids[down_id]
-                    wf_tmpl.link(up_tmpl, down_tmpl)
+            wf_tmpl.dag.validate()
         except KeyError as exc:
             raise TemplateGraphError(exc.args[0]) from exc
 


### PR DESCRIPTION
Using `timeit` on the new DAG topological sort:
* Old topo sort: `0.13291587200001231`
* New topo sort: `0.00799440099945059`

The OverrunPolicy was also reviewed to avoid too much unnecessary list compositions.
This will greatly improve the startup speed of workflows in big volumes.